### PR TITLE
Rework object implementation

### DIFF
--- a/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
+++ b/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
@@ -179,8 +179,8 @@ pub(crate) fn class_name(nm: &str) -> Result<String> {
 
 pub(crate) fn parameter(arg: &Argument) -> Result<String> {
     Ok(match arg.as_type() {
-        Type::Object { name, .. } => {
-            format!("const {} &{}", name, arg.name())
+        Type::Object { .. } => {
+            format!("const {} &{}", arg.as_codetype().type_label(), arg.name())
         }
         Type::CallbackInterface { name, .. } => {
             format!("std::shared_ptr<{}> {}", name, arg.name())

--- a/bindgen/src/bindings/cpp/gen_cpp/object.rs
+++ b/bindgen/src/bindings/cpp/gen_cpp/object.rs
@@ -15,11 +15,11 @@ impl ObjectCodeType {
 
 impl CodeType for ObjectCodeType {
     fn type_label(&self) -> String {
-        CppCodeOracle.class_name(&self.id)
+        format!("std::shared_ptr<{}>", self.canonical_name())
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.id)
+        CppCodeOracle.class_name(&self.id)
     }
 
     fn literal(&self, _literal: &Literal) -> String {

--- a/bindgen/src/bindings/cpp/templates/obj.cpp
+++ b/bindgen/src/bindings/cpp/templates/obj.cpp
@@ -3,26 +3,27 @@
 {%- let type_name = typ|type_name %}
 {%- let class_name = type_name|class_name %}
 {%- let ffi_converter_name = typ|ffi_converter_name %}
+{%- let canonical_type_name = typ|canonical_name %}
 
 namespace {{ namespace }} {
-    {{ class_name }}::{{ class_name }}(void *ptr): instance(ptr) {}
+    {{ canonical_type_name }}::{{ canonical_type_name }}(void *ptr): instance(ptr) {}
 
     {% match obj.primary_constructor() %}
     {%- when Some with (ctor) %}
-    std::unique_ptr<{{ class_name }}> {{ class_name }}::init ({% call macros::param_list(ctor) %}) {
-        return std::unique_ptr<{{ class_name }}>(new {{ class_name }}({% call macros::rust_call(ctor) %}));
+    {{ type_name }} {{ canonical_type_name }}::init({% call macros::param_list(ctor) %}) {
+        return {{ type_name }}(new {{ canonical_type_name }}({% call macros::rust_call(ctor) %}));
     }
     {%- else %}
     {%- endmatch %}
     {%- for ctor in obj.alternate_constructors() %}
-    std::unique_ptr<{{ class_name }}> {{ class_name }}::{{ ctor.name() }}({% call macros::param_list(ctor) %}) {
-        return std::unique_ptr<{{ class_name }}>(new {{ class_name }}({% call macros::rust_call(ctor) %}));
+    {{ type_name }} {{ canonical_type_name }}::{{ ctor.name() }}({% call macros::param_list(ctor) %}) {
+        return {{ type_name }}(new {{ canonical_type_name }}({% call macros::rust_call(ctor) %}));
     }
     {%- endfor %}
 
     {% for method in obj.methods() %}
     {%- match method.return_type() %}{% when Some with (return_type) %}{{ return_type|type_name }} {% else %}void {% endmatch -%}
-    {{ class_name }}::{{ method.name()|fn_name }}({% call macros::param_list(method) %}) {
+    {{ canonical_type_name }}::{{ method.name()|fn_name }}({% call macros::param_list(method) %}) {
         {% match method.return_type() %}
         {%- when Some with (return_type) %}
         return {{ namespace }}::uniffi::{{ return_type|lift_fn }}({% call macros::rust_call_with_prefix("this->instance", method) %});
@@ -32,27 +33,35 @@ namespace {{ namespace }} {
     }
     {% endfor %}
 
-    {{ class_name }} uniffi::{{ ffi_converter_name }}::lift(void *ptr) {
-        return {{ class_name }}(ptr);
+    {{ canonical_type_name }}::~{{ canonical_type_name }}() {
+        {{ namespace }}::uniffi::rust_call(
+            {{ obj.ffi_object_free().name() }},
+            nullptr,
+            this->instance
+        );
     }
 
-    void *uniffi::{{ ffi_converter_name }}::lower(const {{ class_name }} &obj) {
-        return obj.instance;
+    {{ type_name }} uniffi::{{ ffi_converter_name }}::lift(void *ptr) {
+        return {{ type_name }}(new {{ canonical_type_name }}(ptr));
     }
 
-    {{ class_name }} uniffi::{{ ffi_converter_name }}::read(RustStream &stream) {
+    void *uniffi::{{ ffi_converter_name }}::lower(const {{ type_name }} &obj) {
+        return obj->instance;
+    }
+
+    {{ type_name }} uniffi::{{ ffi_converter_name }}::read(RustStream &stream) {
         std::uintptr_t ptr;
 
         stream >> ptr;
 
-        return {{ class_name }}(reinterpret_cast<void *>(ptr));
+        return {{ type_name }}(new {{ canonical_type_name }}(reinterpret_cast<void *>(ptr)));
     }
 
-    void uniffi::{{ ffi_converter_name }}::write(RustStream &stream, const {{ class_name }} &obj) {
-        stream << reinterpret_cast<std::uintptr_t>(obj.instance);
+    void uniffi::{{ ffi_converter_name }}::write(RustStream &stream, const {{ type_name }} &obj) {
+        stream << reinterpret_cast<std::uintptr_t>(obj->instance);
     }
 
-    int32_t uniffi::{{ ffi_converter_name }}::allocation_size(const {{ class_name }} &) {
+    int32_t uniffi::{{ ffi_converter_name }}::allocation_size(const {{ type_name }} &) {
         return 8;
     }
 }

--- a/bindgen/src/bindings/cpp/templates/obj.hpp
+++ b/bindgen/src/bindings/cpp/templates/obj.hpp
@@ -1,34 +1,40 @@
 {%- let obj = ci|get_object_definition(name) %}
 {%- let class_name = type_name|class_name %}
 {%- let ffi_converter_name = typ|ffi_converter_name %}
+{%- let canonical_type_name = typ|canonical_name %}
+{%- let type_name = typ|type_name %}
 
 namespace uniffi { struct {{ ffi_converter_name|class_name }}; }
-struct {{ class_name }} {
+struct {{ canonical_type_name }} {
     friend uniffi::{{ ffi_converter_name|class_name }};
 
-    {{ class_name }}(const {{ class_name }} &) = default;
-    {{ class_name }}({{ class_name }} &&) = default;
+    {{ canonical_type_name }}(const {{ canonical_type_name }} &) = default;
+    {{ canonical_type_name }}({{ canonical_type_name }} &&) = default;
 
-    {{ class_name }} &operator=(const {{ class_name }} &) = default;
-    {{ class_name }} &operator=({{ class_name }} &&) = default;
+    {{ canonical_type_name }} &operator=(const {{ canonical_type_name }} &) = default;
+    {{ canonical_type_name }} &operator=({{ canonical_type_name }} &&) = default;
 
     {% match obj.primary_constructor() %}
     {%- when Some with (ctor) -%}
-    static std::unique_ptr<{{ class_name }}> init({% call macros::param_list(ctor) %});
+    static {{ type_name }} init({% call macros::param_list(ctor) %});
     {%- else %}
     {%- endmatch -%}
 
     {% for ctor in obj.alternate_constructors() %}
-    static std::unique_ptr<{{ class_name }}> {{ ctor.name() }}({% call macros::param_list(ctor) %});
+    static {{ type_name }} {{ ctor.name() }}({% call macros::param_list(ctor) %});
     {%- endfor %}
+
+    ~{{ canonical_type_name }}();
 
     {% for method in obj.methods() %}
     {%- match method.return_type() %}{% when Some with (return_type) %}{{ return_type|type_name }} {% else %}void {% endmatch %}
     {{- method.name()|fn_name }}({% call macros::param_list(method) %});
     {% endfor %}
+
 private:
-    {{ class_name }}(void *);
-    {{ class_name }}() = delete;
+    {{ canonical_type_name }}(void *);
+    {{ canonical_type_name }}() = delete;
+
 
     void *instance;
 };

--- a/bindgen/src/bindings/cpp/templates/obj_conv.hpp
+++ b/bindgen/src/bindings/cpp/templates/obj_conv.hpp
@@ -1,12 +1,11 @@
 {%- let rec = ci.get_object_definition(name).unwrap() %}
 {%- let type_name = typ|type_name %}
-{%- let class_name = type_name|class_name %}
 
 struct {{ typ|ffi_converter_name }} {
-    static {{ class_name }} lift(void *);
-    static void *lower(const {{ class_name }} &);
-    static {{ class_name }} read(uniffi::RustStream &);
+    static {{ type_name }} lift(void *);
+    static void *lower(const {{ type_name }} &);
+    static {{ type_name }} read(uniffi::RustStream &);
     static void write({{ namespace }}::uniffi::RustStream &, const {{ type_name }} &);
 
-    static int32_t allocation_size(const {{ class_name }} &);
+    static int32_t allocation_size(const {{ type_name }} &);
 };

--- a/bindgen/src/bindings/cpp/templates/opt_conv.hpp
+++ b/bindgen/src/bindings/cpp/templates/opt_conv.hpp
@@ -2,8 +2,8 @@
 
 struct {{ typ|ffi_converter_name }} {
     static {{ type_name }} lift(RustBuffer buf);
-    static RustBuffer lower({{ type_name }} val);
+    static RustBuffer lower(const {{ type_name }}& val);
     static {{ type_name }} read({{ namespace }}::uniffi::RustStream &stream);
-    static void write({{ namespace }}::uniffi::RustStream &stream, {{ type_name }} value);
+    static void write({{ namespace }}::uniffi::RustStream &stream, const {{ type_name }}& value);
     static int32_t allocation_size(const {{ type_name }} &val);
 };

--- a/bindgen/src/bindings/cpp/templates/opt_tmpl.cpp
+++ b/bindgen/src/bindings/cpp/templates/opt_tmpl.cpp
@@ -8,7 +8,7 @@ namespace {{ namespace }} {
         return ret;
     }
 
-    RustBuffer {{ namespace }}::uniffi::{{ ffi_converter_name }}::lower({{ type_name }} val) {
+    RustBuffer {{ namespace }}::uniffi::{{ ffi_converter_name }}::lower(const {{ type_name }}& val) {
         auto buf = {{ namespace }}::uniffi::rustbuffer_alloc({{ namespace }}::uniffi::{{ ffi_converter_name }}::allocation_size(val));
         auto stream = {{ namespace }}::uniffi::RustStream(&buf);
 
@@ -29,7 +29,7 @@ namespace {{ namespace }} {
         return std::nullopt;
     }
 
-    void {{ namespace }}::uniffi::{{ ffi_converter_name }}::write({{ namespace }}::uniffi::RustStream &stream, {{ type_name }} value) {
+    void {{ namespace }}::uniffi::{{ ffi_converter_name }}::write({{ namespace }}::uniffi::RustStream &stream, const {{ type_name }}& value) {
         stream.put(static_cast<uint8_t>(!!value));
 
         if (value) {

--- a/cpp-tests/tests/todolist/main.cpp
+++ b/cpp-tests/tests/todolist/main.cpp
@@ -53,28 +53,28 @@ int main() {
 
     auto todo2 = todolist::TodoList::init();
     {
-        todolist::set_default_list(*todo.get());
+        todolist::set_default_list(todo);
         auto default_list_opt = todolist::get_default_list();
         ASSERT_TRUE(default_list_opt.has_value());
         auto default_list = default_list_opt.value();
 
-        ASSERT_TRUE(compare_lists(todo->get_entries(), default_list.get_entries()));    
-        ASSERT_FALSE(compare_lists(todo2->get_entries(), default_list.get_entries()));
+        ASSERT_TRUE(compare_lists(todo->get_entries(), default_list->get_entries()));    
+        ASSERT_FALSE(compare_lists(todo2->get_entries(), default_list->get_entries()));
     }
 
     {
         todo2->make_default();
         auto default_list = todolist::get_default_list().value();
 
-        ASSERT_FALSE(compare_lists(todo->get_entries(), default_list.get_entries()));
-        ASSERT_TRUE(compare_lists(todo2->get_entries(), default_list.get_entries()));
+        ASSERT_FALSE(compare_lists(todo->get_entries(), default_list->get_entries()));
+        ASSERT_TRUE(compare_lists(todo2->get_entries(), default_list->get_entries()));
     }
 
     todo->add_item("Entry after default list change");
     ASSERT_EQ("Entry after default list change", todo->get_last());
 
     todo2->add_item("New default entry");
-    ASSERT_EQ("New default entry", todolist::get_default_list().value().get_last());
+    ASSERT_EQ("New default entry", todolist::get_default_list().value()->get_last());
 
     return 0;
 }

--- a/cpp-tests/tests/traits/main.cpp
+++ b/cpp-tests/tests/traits/main.cpp
@@ -7,10 +7,10 @@ int main() {
     auto expected_names = {"go", "stop"};
 
     for (auto button : buttons) {
-        auto name = button.name();
+        auto name = button->name();
 
         ASSERT_TRUE(std::find(expected_names.begin(), expected_names.end(), name) != expected_names.end());
-        ASSERT_EQ(traits::press(button).name(), name);
+        ASSERT_EQ(traits::press(button)->name(), name);
     }
 
     return 0;


### PR DESCRIPTION
Added missing desctruction logic, which caused memory leaking and Rust objects not being cleaned up, changed wrapper for objects from `unique_ptr` to `shared_ptr`, as shared pointers map more closely to the Rust model of handling objects wiht `Arc`'s under the hood, and updated tests accordingly