### PR TITLE
Dereference optional object type

### DIFF
--- a/bindgen/src/bindings/cpp/gen_cpp/compounds.rs
+++ b/bindgen/src/bindings/cpp/gen_cpp/compounds.rs
@@ -14,14 +14,25 @@ impl OptionalCodeType {
     pub(crate) fn new(inner: Type) -> Self {
         Self { inner }
     }
+
+    pub(crate) fn can_dereference(inner_type: &Type) -> bool {
+        match inner_type {
+            Type::Object { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 impl CodeType for OptionalCodeType {
     fn type_label(&self) -> String {
-        format!(
-            "std::optional<{}>",
+        if OptionalCodeType::can_dereference(&self.inner) {
             CppCodeOracle.find(&self.inner).type_label()
-        )
+        } else {
+            format!(
+                "std::optional<{}>",
+                CppCodeOracle.find(&self.inner).type_label()
+            )
+        }
     }
 
     fn canonical_name(&self) -> String {

--- a/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
+++ b/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
@@ -195,3 +195,11 @@ pub(crate) fn docstring(docstring: &str, spaces: &i32) -> Result<String> {
 
     Ok(textwrap::indent(&wrapped, &" ".repeat(*spaces as usize)))
 }
+
+pub(crate) fn can_dereference_optional(type_: &Type) -> Result<bool> {
+    let result = match type_ {
+        Type::Optional { inner_type } => compounds::OptionalCodeType::can_dereference(inner_type),
+        _ => false,
+    };
+    Ok(result)
+}

--- a/bindgen/src/bindings/cpp/mod.rs
+++ b/bindgen/src/bindings/cpp/mod.rs
@@ -67,7 +67,11 @@ impl BindingGenerator for CppBindingGenerator {
         Ok(())
     }
 
-    fn check_library_path(&self, _library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
+    fn check_library_path(
+        &self,
+        _library_path: &Utf8Path,
+        cdylib_name: Option<&str>,
+    ) -> Result<()> {
         if cdylib_name.is_none() {
             bail!("A path to a library file is required to generate bindings");
         }

--- a/cpp-tests/tests/coverall/main.cpp
+++ b/cpp-tests/tests/coverall/main.cpp
@@ -26,7 +26,7 @@ void test_some_dict() {
     ASSERT_EQ(22.0f / 7.0f, dict.maybe_float32);
     ASSERT_EQ(0.0, dict.float64);
     ASSERT_EQ(1.0, dict.maybe_float64);
-    ASSERT_EQ("some_dict", dict.coveralls.value()->get_name());
+    ASSERT_EQ("some_dict", dict.coveralls->get_name());
 }
 
 void test_arcs() {
@@ -35,7 +35,7 @@ void test_arcs() {
 
         ASSERT_EQ(1ul, coverall::get_num_alive());
         ASSERT_EQ(2ul, coveralls->strong_count());
-        ASSERT_EQ(std::nullopt, coveralls->get_other());
+        ASSERT_EQ(nullptr, coveralls->get_other());
 
         coveralls->take_other(coveralls);
         ASSERT_EQ(3ul, coveralls->strong_count());
@@ -43,14 +43,14 @@ void test_arcs() {
 
         {
             auto other = coveralls->get_other();
-            ASSERT_EQ("test_arcs", other.value()->get_name());
+            ASSERT_EQ("test_arcs", other->get_name());
         }
 
         EXPECT_EXCEPTION(coveralls->take_other_fallible(), coverall::coverall_error::TooManyHoles);
         EXPECT_EXCEPTION(coveralls->take_other_panic("take_other_panic"), std::runtime_error);
         EXPECT_EXCEPTION(coveralls->fallible_panic("fallible_panic"), std::runtime_error);
 
-        coveralls->take_other(std::nullopt);
+        coveralls->take_other(nullptr);
         ASSERT_EQ(2ul, coveralls->strong_count());
     }
 

--- a/cpp-tests/tests/todolist/main.cpp
+++ b/cpp-tests/tests/todolist/main.cpp
@@ -49,14 +49,13 @@ int main() {
     ASSERT_EQ(9, todo->get_entries().size());
     ASSERT_EQ("List 1", todo->get_items()[7]);
 
-    ASSERT_EQ(std::nullopt, todolist::get_default_list());
+    ASSERT_EQ(nullptr, todolist::get_default_list());
 
     auto todo2 = todolist::TodoList::init();
     {
         todolist::set_default_list(todo);
-        auto default_list_opt = todolist::get_default_list();
-        ASSERT_TRUE(default_list_opt.has_value());
-        auto default_list = default_list_opt.value();
+        auto default_list = todolist::get_default_list();
+        ASSERT_TRUE(default_list);
 
         ASSERT_TRUE(compare_lists(todo->get_entries(), default_list->get_entries()));    
         ASSERT_FALSE(compare_lists(todo2->get_entries(), default_list->get_entries()));
@@ -64,7 +63,7 @@ int main() {
 
     {
         todo2->make_default();
-        auto default_list = todolist::get_default_list().value();
+        auto default_list = todolist::get_default_list();
 
         ASSERT_FALSE(compare_lists(todo->get_entries(), default_list->get_entries()));
         ASSERT_TRUE(compare_lists(todo2->get_entries(), default_list->get_entries()));
@@ -74,7 +73,7 @@ int main() {
     ASSERT_EQ("Entry after default list change", todo->get_last());
 
     todo2->add_item("New default entry");
-    ASSERT_EQ("New default entry", todolist::get_default_list().value()->get_last());
+    ASSERT_EQ("New default entry", todolist::get_default_list()->get_last());
 
     return 0;
 }


### PR DESCRIPTION
`optional<shared_ptr<T>>` does not make sense for C++, since `shared_ptr<T>` can represent empty state by itself.

The transformation is implemented in couple of steps:
1. Remove `optional<>` for type labels to make `optional<shared_ptr<T>>` appear as `shared_ptr<T>` where the optional type is referenced

2. To maintain RustBuffer ABI compatibility, optional converter converts from `optional<shared_ptr<T>>` to `shared_ptr<T>` while keeping the read/write logic for optional byte.