### PR TITLE
Honor uniffi's `[ByRef]` tag

### DIFF
--- a/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
+++ b/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
@@ -178,12 +178,10 @@ pub(crate) fn class_name(nm: &str) -> Result<String> {
 }
 
 pub(crate) fn parameter(arg: &Argument) -> Result<String> {
-    Ok(match arg.as_type() {
-        Type::Object { .. } | Type::CallbackInterface { .. } => {
-            format!("const {} &{}", arg.as_codetype().type_label(), arg.name())
-        }
-        t => format!("{} {}", type_name(&t)?, arg.name()),
-    })
+    match arg.by_ref() {
+        true => Ok(format!("const {} &{}", type_name(&arg)?, arg.name())),
+        false => Ok(format!("{} {}", type_name(&arg)?, arg.name())),
+    }
 }
 
 pub(crate) fn docstring(docstring: &str, spaces: &i32) -> Result<String> {

--- a/bindgen/src/bindings/cpp/templates/scaffolding/callback.cpp
+++ b/bindgen/src/bindings/cpp/templates/scaffolding/callback.cpp
@@ -18,7 +18,7 @@ class {{ iface.name() }}Proxy: public {{ iface.name() }} {
             {%- match m.return_type() -%}
             {% when Some with (return_type) %}{{ return_type|type_name }} {% when None %}void {% endmatch %}{{ m.name() }}(
             {%- for arg in m.arguments() %}
-            {{- arg.as_type().borrow()|type_name }} {{ arg.name() }}{% if !loop.last %}, {% endif -%}
+            {{- arg|parameter }} {% if !loop.last %}, {% endif -%}
             {% endfor %}) override {
                 ForeignCallback *callback_stub = reinterpret_cast<ForeignCallback *>({{ ffi_converter_name|class_name }}::fn_handle.load());
                 if (callback_stub == nullptr) {

--- a/cpp-tests/scaffolding_tests/custom_fixture_callbacks/lib_custom_fixture_callbacks.cpp
+++ b/cpp-tests/scaffolding_tests/custom_fixture_callbacks/lib_custom_fixture_callbacks.cpp
@@ -37,6 +37,18 @@ custom_fixture_callbacks::Enumeration custom_fixture_callbacks::NativeGetters::g
     return cb->get_enum(v, variant, arg2);
 }
 
+std::string custom_fixture_callbacks::NativeGetters::get_string_by_ref(std::shared_ptr<ForeignGetters> cb, const std::string& v, bool arg2) {
+    return cb->get_string_by_ref(v, arg2);
+}
+
+std::vector<int32_t> custom_fixture_callbacks::NativeGetters::get_list_by_ref(std::shared_ptr<ForeignGetters> cb, const std::vector<int32_t>& v, bool arg2) {
+    return cb->get_list_by_ref(v, arg2);
+}
+
+std::vector<uint8_t> custom_fixture_callbacks::NativeGetters::get_bytes_by_ref(std::shared_ptr<ForeignGetters> cb, const std::vector<uint8_t>& v, bool arg2) {
+    return cb->get_bytes_by_ref(v, arg2);
+}
+
 std::string custom_fixture_callbacks::NativeStringifier::from_simple_type(int32_t value) {
     return cb->from_simple_type(value);
 }

--- a/cpp-tests/scaffolding_tests/custom_fixture_callbacks/lib_custom_fixture_callbacks.hpp
+++ b/cpp-tests/scaffolding_tests/custom_fixture_callbacks/lib_custom_fixture_callbacks.hpp
@@ -26,6 +26,10 @@ namespace {
             virtual void get_nothing(std::string v) = 0;
             virtual Enumeration get_enum(Enumeration v, uint32_t variant, bool arg2) = 0;
 
+            virtual std::string get_string_by_ref(const std::string& v, bool arg2) = 0;
+            virtual std::vector<int32_t> get_list_by_ref(const std::vector<int32_t>& v, bool arg2) = 0;
+            virtual std::vector<uint8_t> get_bytes_by_ref(const std::vector<uint8_t>& v, bool arg2) = 0;
+
             virtual ~ForeignGetters() = default;
         };
 
@@ -47,6 +51,10 @@ namespace {
             std::optional<std::string> get_string_optional_callback(std::shared_ptr<ForeignGetters> cb, std::string v, bool arg2);
             void get_nothing(std::shared_ptr<ForeignGetters> cb, std::string v);
             Enumeration get_enum(std::shared_ptr<ForeignGetters> cb, Enumeration v, uint32_t variant, bool arg2);
+
+            std::string get_string_by_ref(std::shared_ptr<ForeignGetters> cb, const std::string& v, bool arg2);
+            std::vector<int32_t> get_list_by_ref(std::shared_ptr<ForeignGetters> cb, const std::vector<int32_t>& v, bool arg2);
+            std::vector<uint8_t> get_bytes_by_ref(std::shared_ptr<ForeignGetters> cb, const std::vector<uint8_t>& v, bool arg2);
         };
 
         class NativeStringifier {

--- a/cpp-tests/scaffolding_tests/custom_fixture_callbacks/main.cpp
+++ b/cpp-tests/scaffolding_tests/custom_fixture_callbacks/main.cpp
@@ -56,6 +56,18 @@ public:
                 return custom_fixture_callbacks::Enumeration::UNKNOWN;
         }
     }
+
+    virtual std::string get_string_by_ref(const std::string &v, bool arg2) override {
+        return arg2 ? "1234567890123" : v;
+    }
+
+    virtual std::vector<int32_t> get_list_by_ref(const std::vector<int32_t> &v, bool arg2) override {
+        return arg2 ? v : std::vector<int32_t>();
+    }
+
+    virtual std::vector<uint8_t> get_bytes_by_ref(const std::vector<uint8_t> &v, bool arg2) override {
+        return arg2 ? v : std::vector<uint8_t>();
+    }
 };
 
 struct CppStringifier : public custom_fixture_callbacks::StoredForeignStringifier {
@@ -91,15 +103,18 @@ int main() {
     auto flag = true;
 
     ASSERT_EQ(cb->get_string("test", flag), native_cb->get_string(cb, "test", flag));
+    ASSERT_EQ(cb->get_string_by_ref("test", flag), native_cb->get_string_by_ref(cb, "test", flag));
     ASSERT_EQ(cb->get_bool(true, flag), native_cb->get_bool(cb, true, flag));
     ASSERT_EQ(cb->get_bool(false, flag), native_cb->get_bool(cb, false, flag));
 
     for (auto list : {std::vector<int32_t>{1, 2}, std::vector<int32_t>{0, 1}}) {
         ASSERT_EQ(cb->get_list(list, flag), native_cb->get_list(cb, list, flag));
+        ASSERT_EQ(cb->get_list_by_ref(list, flag), native_cb->get_list_by_ref(cb, list, flag));
     }
 
     for (auto str : {"Hello", "World"}) {
         ASSERT_EQ(cb->get_string(str, flag), native_cb->get_string(cb, str, flag));
+        ASSERT_EQ(cb->get_string_by_ref(str, flag), native_cb->get_string_by_ref(cb, str, flag));
     }
 
     for (auto opt : {std::optional<std::string>("Hello"), std::optional<std::string>(std::nullopt)}) {
@@ -111,6 +126,7 @@ int main() {
 
     for (auto bytes : {std::vector<uint8_t>{1, 2}, std::vector<uint8_t>{0, 1}}) {
         ASSERT_EQ(cb->get_bytes(bytes, flag), native_cb->get_bytes(cb, bytes, flag));
+        ASSERT_EQ(cb->get_bytes_by_ref(bytes, flag), native_cb->get_bytes_by_ref(cb, bytes, flag));
     }
 
     for (auto enum_val : {custom_fixture_callbacks::Enumeration::A, custom_fixture_callbacks::Enumeration::B, custom_fixture_callbacks::Enumeration::C}) {

--- a/cpp-tests/scaffolding_tests/custom_fixture_callbacks/udl/custom_callback_fixtures.udl
+++ b/cpp-tests/scaffolding_tests/custom_fixture_callbacks/udl/custom_callback_fixtures.udl
@@ -15,6 +15,10 @@ callback interface ForeignGetters {
     bytes get_bytes(bytes v, boolean arg2);
     void get_nothing(string v);
     Enumeration get_enum(Enumeration v, u32 variant, boolean arg2);
+
+    string get_string_by_ref([ByRef] string v, boolean arg2);
+    sequence<i32> get_list_by_ref([ByRef] sequence<i32> v, boolean arg2);
+    bytes get_bytes_by_ref([ByRef] bytes v, boolean arg2);
 };
 
 interface NativeGetters {
@@ -28,6 +32,10 @@ interface NativeGetters {
     string? get_string_optional_callback(ForeignGetters? callback, string v, boolean arg2);
     void get_nothing(ForeignGetters callback, string v);
     Enumeration get_enum(ForeignGetters callback, Enumeration v, u32 variant, boolean arg2);
+
+    string get_string_by_ref(ForeignGetters callback, [ByRef] string v, boolean arg2);
+    sequence<i32> get_list_by_ref(ForeignGetters callback, [ByRef] sequence<i32> v, boolean arg2);
+    bytes get_bytes_by_ref(ForeignGetters callback, [ByRef] bytes v, boolean arg2);
 };
 
 callback interface StoredForeignStringifier {

--- a/cpp-tests/scaffolding_tests/sprites/lib_sprites.cpp
+++ b/cpp-tests/scaffolding_tests/sprites/lib_sprites.cpp
@@ -1,6 +1,6 @@
 #include "lib_sprites.hpp"
 
-sprites::Point sprites::translate(Point position, Vector direction) {
+sprites::Point sprites::translate(const Point &position, Vector direction) {
     return sprites::Point { position.x + direction.dx, position.y + direction.dy };
 }
 

--- a/cpp-tests/scaffolding_tests/sprites/lib_sprites.hpp
+++ b/cpp-tests/scaffolding_tests/sprites/lib_sprites.hpp
@@ -23,6 +23,6 @@ namespace {
             void move_by(Vector vector);
         };
 
-        Point translate(Point point, Vector vector);
+        Point translate(const Point &point, Vector vector);
     }
 }

--- a/cpp-tests/scaffolding_tests/sprites/main.cpp
+++ b/cpp-tests/scaffolding_tests/sprites/main.cpp
@@ -23,5 +23,10 @@ int main() {
     ASSERT_EQ(rel->get_position().x, 1.0);
     ASSERT_EQ(rel->get_position().y, 2.5);
 
+    auto p = sprites::Point { 1.0, 2.0 };
+    auto t_p = sprites::translate(p, sprites::Vector { 1.0, 1.5 });
+    ASSERT_EQ(t_p.x, 2.0);
+    ASSERT_EQ(t_p.y, 3.5);
+
     return 0;
 }

--- a/cpp-tests/tests/sprites/main.cpp
+++ b/cpp-tests/tests/sprites/main.cpp
@@ -23,5 +23,10 @@ int main() {
     ASSERT_EQ(rel->get_position().x, 1.0);
     ASSERT_EQ(rel->get_position().y, 2.5);
 
+    auto p = sprites::Point { 1.0, 2.0 };
+    auto t_p = sprites::translate(p, sprites::Vector { 1.0, 1.5 });
+    ASSERT_EQ(t_p.x, 2.0);
+    ASSERT_EQ(t_p.y, 3.5);
+
     return 0;
 }

--- a/docs/SCAFFOLDING.md
+++ b/docs/SCAFFOLDING.md
@@ -39,6 +39,7 @@ To ensure that the generated code is able to interface with the target C++ libra
 - For object types, all constructors mentioned in the UDL file should have a matching public constructor in the C++ library.
 - When exposing callback interfaces, it is recommended to not have any processing-intensive or global data modifying logic in the constructors and destructors of the backing C++ class, as due to the way uniffi internally handles callback interfaces, callback instances may be dynamically constructed multiple times during the runtime of the application.
 - All of the exports mentioned in the UDL file should be under the same namespace that is specified in the `Cargo.toml` file in the C++ library.
+- All arguments are passed value by default, to pass an argument by reference the `[ByRef]` tag has to be used.
 
 Some of the types in the UDL file might not have a direct mapping to a C++ type. To see the full list of mappings, refer to the [UDL to C++ type mapping](#udl-to-c-type-mapping-table) table.
 


### PR DESCRIPTION
Instead of selectively choosing which argument types are passed by reference, default to passing by value and honor the `[ByRef]` tag from the UDL definition, this leaves out guesswork from the library side, on which arguments are meant to be passed by reference and does not stray away from how uniffi-rs handles arguments