### PR TITLE
Clean up templates

### DIFF
--- a/bindgen/src/bindings/cpp/templates/cpp_scaffolding.cpp
+++ b/bindgen/src/bindings/cpp/templates/cpp_scaffolding.cpp
@@ -163,7 +163,7 @@ UNIFFI_EXPORT RustBuffer {{ ci.ffi_rustbuffer_reserve().name() }}(RustBuffer buf
 {% let ffi_func = func.ffi_func() %}
 UNIFFI_EXPORT {%- call macros::fn_definition(ffi_func) %} {
     {%- call macros::fn_prologue(ci, func, ffi_func) %}
-    {%- call macros::invoke_native_fn(func, "{}::"|format(namespace)) %}
+    {%- call macros::invoke_native_fn(func, namespace) %}
     {%- call macros::fn_epilogue(ci, func, ffi_func) %}
 }
 {% endfor %}
@@ -208,7 +208,7 @@ UNIFFI_EXPORT {%- call macros::fn_definition(ffi_dtor) %} {
 UNIFFI_EXPORT {%- call macros::fn_definition(ffi_func) %} {
     {%- call macros::fn_prologue(ci, func, ffi_func) %}
     auto obj = {{ obj.name() }}_map.at((uint64_t)ptr);
-    {%- call macros::invoke_native_fn(func, "obj->") %}
+    {%- call macros::invoke_native_fn_obj(func) %}
     {%- call macros::fn_epilogue(ci, func, ffi_func) %}
 }
 {% endfor %}

--- a/bindgen/src/bindings/cpp/templates/cpp_scaffolding.cpp
+++ b/bindgen/src/bindings/cpp/templates/cpp_scaffolding.cpp
@@ -50,55 +50,7 @@ struct RustCallStatus {
 
 typedef int ForeignCallback(uint64_t handle, uint32_t method, uint8_t *args_data, int32_t args_len, RustBuffer *buf_ptr);
 
-struct RustStreamBuffer: std::basic_streambuf<uint8_t> {
-    RustStreamBuffer(RustBuffer *buf) {
-        this->setg(buf->data, buf->data, buf->data + buf->len);
-        this->setp(buf->data, buf->data + buf->capacity);
-    }
-    ~RustStreamBuffer() = default;
-
-private:
-    RustStreamBuffer() = delete;
-    RustStreamBuffer(const RustStreamBuffer &) = delete;
-    RustStreamBuffer(RustStreamBuffer &&) = delete;
-
-    RustStreamBuffer &operator=(const RustStreamBuffer &) = delete;
-    RustStreamBuffer &operator=(RustStreamBuffer &&) = delete;
-};
-
-struct RustStream: std::basic_iostream<uint8_t> {
-    RustStream(RustBuffer *buf):
-        streambuf(RustStreamBuffer(buf)), std::basic_iostream<uint8_t>(&streambuf) { }
-
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
-    RustStream &operator>>(T &val) {
-        read(reinterpret_cast<uint8_t *>(&val), sizeof(T));
-
-        if (std::endian::native != std::endian::big) {
-            auto bytes = reinterpret_cast<char *>(&val);
-
-            std::reverse(bytes, bytes + sizeof(T));
-        }
-
-        return *this;
-    }
-
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
-    RustStream &operator<<(T val) {
-        if (std::endian::native != std::endian::big) {
-            auto bytes = reinterpret_cast<char *>(&val);
-
-            std::reverse(bytes, bytes + sizeof(T));
-        }
-
-        write(reinterpret_cast<uint8_t *>(&val), sizeof(T));
-
-        return *this;
-    }
-private:
-    RustStreamBuffer streambuf;
-};
-
+{%- include "rust_buf_stream.cpp" %}
 {%- include "scaffolding/object_map.cpp" %}
 
 {%- for typ in ci.iter_types() %}

--- a/bindgen/src/bindings/cpp/templates/rust_buf_stream.cpp
+++ b/bindgen/src/bindings/cpp/templates/rust_buf_stream.cpp
@@ -1,0 +1,49 @@
+struct RustStreamBuffer: std::basic_streambuf<uint8_t> {
+    RustStreamBuffer(RustBuffer *buf) {
+        this->setg(buf->data, buf->data, buf->data + buf->len);
+        this->setp(buf->data, buf->data + buf->capacity);
+    }
+    ~RustStreamBuffer() = default;
+
+private:
+    RustStreamBuffer() = delete;
+    RustStreamBuffer(const RustStreamBuffer &) = delete;
+    RustStreamBuffer(RustStreamBuffer &&) = delete;
+
+    RustStreamBuffer &operator=(const RustStreamBuffer &) = delete;
+    RustStreamBuffer &operator=(RustStreamBuffer &&) = delete;
+};
+
+struct RustStream: std::basic_iostream<uint8_t> {
+    RustStream(RustBuffer *buf):
+        streambuf(RustStreamBuffer(buf)), std::basic_iostream<uint8_t>(&streambuf) { }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    RustStream &operator>>(T &val) {
+        read(reinterpret_cast<uint8_t *>(&val), sizeof(T));
+
+        if (std::endian::native != std::endian::big) {
+            auto bytes = reinterpret_cast<char *>(&val);
+
+            std::reverse(bytes, bytes + sizeof(T));
+        }
+
+        return *this;
+    }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    RustStream &operator<<(T val) {
+        if (std::endian::native != std::endian::big) {
+            auto bytes = reinterpret_cast<char *>(&val);
+
+            std::reverse(bytes, bytes + sizeof(T));
+        }
+
+        write(reinterpret_cast<uint8_t *>(&val), sizeof(T));
+
+        return *this;
+    }
+private:
+    RustStreamBuffer streambuf;
+};
+

--- a/bindgen/src/bindings/cpp/templates/scaffolding/macros.cpp
+++ b/bindgen/src/bindings/cpp/templates/scaffolding/macros.cpp
@@ -31,16 +31,34 @@
 {%- endif %}
 {% endmacro %}
 
-{% macro invoke_native_fn(scaffolding_fn, prefix) %}
+{% macro invoke_native_fn(scaffolding_fn, namespace) %}
 {% match func.return_type() %}
 {% when Some with (return_type) %}
-auto ret = {{ prefix }}{{ scaffolding_fn.name() }}(
+auto ret = {{ namespace }}::{{ scaffolding_fn.name() }}(
 {%- for arg in scaffolding_fn.arguments() %}
 {{- arg|lift_fn }}({{ arg.name()|var_name }}){% if !loop.last %}, {% endif -%}
 {% endfor %});
 return {{ return_type|lower_fn }}(ret);
 {% when None %}
-{{ prefix }}{{ scaffolding_fn.name() }}(
+{{ namespace }}::{{ scaffolding_fn.name() }}(
+{%- for arg in scaffolding_fn.arguments() %}
+{{- arg|lift_fn }}({{ arg.name()|var_name }}){% if !loop.last %}, {% endif -%}
+{% endfor %});
+{% endmatch %}
+{% endmacro %}
+
+{% macro invoke_native_fn_obj(scaffolding_fn) %}
+{% match func.return_type() %}
+{% when Some with (return_type) %}
+auto ret = obj->{{ scaffolding_fn.name() }}(
+{% if scaffolding_fn.takes_self_by_arc() %}obj{% if !scaffolding_fn.arguments().is_empty() %},{% endif %}{% endif %}
+{%- for arg in scaffolding_fn.arguments() %}
+{{- arg|lift_fn }}({{ arg.name()|var_name }}){% if !loop.last %}, {% endif -%}
+{% endfor %});
+return {{ return_type|lower_fn }}(ret);
+{% when None %}
+obj->{{ scaffolding_fn.name() }}(
+{% if scaffolding_fn.takes_self_by_arc() %}obj{% if !scaffolding_fn.arguments().is_empty() %},{% endif %}{% endif %}
 {%- for arg in scaffolding_fn.arguments() %}
 {{- arg|lift_fn }}({{ arg.name()|var_name }}){% if !loop.last %}, {% endif -%}
 {% endfor %});

--- a/bindgen/src/bindings/cpp/templates/wrapper.hpp
+++ b/bindgen/src/bindings/cpp/templates/wrapper.hpp
@@ -79,54 +79,7 @@ typedef {{ type_name }} {{ name }};
 {%- endfor %}
 
 namespace uniffi {
-struct RustStreamBuffer: std::basic_streambuf<uint8_t> {
-    RustStreamBuffer(RustBuffer *buf) {
-        this->setg(buf->data, buf->data, buf->data + buf->len);
-        this->setp(buf->data, buf->data + buf->capacity);
-    }
-    ~RustStreamBuffer() = default;
-
-private:
-    RustStreamBuffer() = delete;
-    RustStreamBuffer(const RustStreamBuffer &) = delete;
-    RustStreamBuffer(RustStreamBuffer &&) = delete;
-
-    RustStreamBuffer &operator=(const RustStreamBuffer &) = delete;
-    RustStreamBuffer &operator=(RustStreamBuffer &&) = delete;
-};
-
-struct RustStream: std::basic_iostream<uint8_t> {
-    RustStream(RustBuffer *buf):
-        streambuf(RustStreamBuffer(buf)), std::basic_iostream<uint8_t>(&streambuf) { }
-
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
-    RustStream &operator>>(T &val) {
-        read(reinterpret_cast<uint8_t *>(&val), sizeof(T));
-
-        if (std::endian::native != std::endian::big) {
-            auto bytes = reinterpret_cast<char *>(&val);
-
-            std::reverse(bytes, bytes + sizeof(T));
-        }
-
-        return *this;
-    }
-
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
-    RustStream &operator<<(T val) {
-        if (std::endian::native != std::endian::big) {
-            auto bytes = reinterpret_cast<char *>(&val);
-
-            std::reverse(bytes, bytes + sizeof(T));
-        }
-
-        write(reinterpret_cast<uint8_t *>(&val), sizeof(T));
-
-        return *this;
-    }
-private:
-    RustStreamBuffer streambuf;
-};
+{%- include "rust_buf_stream.cpp" %}
 
 RustBuffer rustbuffer_alloc(int32_t);
 RustBuffer rustbuffer_from_bytes(const ForeignBytes &);

--- a/cpp-tests/scaffolding_tests/coverall/lib_coverall.cpp
+++ b/cpp-tests/scaffolding_tests/coverall/lib_coverall.cpp
@@ -117,11 +117,11 @@ std::shared_ptr<coverall::Coveralls> coverall::Coveralls::get_other() {
     return this->other;
 }
 
-void coverall::Coveralls::take_other_fallible() {
+void coverall::Coveralls::take_other_fallible(const std::shared_ptr<Coveralls> &self) {
     throw coverall::coverall_error::TooManyHoles();
 }
 
-void coverall::Coveralls::take_other_panic(std::string message) {
+void coverall::Coveralls::take_other_panic(const std::shared_ptr<Coveralls> &self, std::string message) {
     throw std::runtime_error(message);
 }
 

--- a/cpp-tests/scaffolding_tests/coverall/lib_coverall.hpp
+++ b/cpp-tests/scaffolding_tests/coverall/lib_coverall.hpp
@@ -91,8 +91,8 @@ namespace {
 
             void take_other(const std::shared_ptr<Coveralls> &other);
             std::shared_ptr<Coveralls> get_other();
-            void take_other_fallible();
-            void take_other_panic(std::string message);
+            void take_other_fallible(const std::shared_ptr<Coveralls> &self);
+            void take_other_panic(const std::shared_ptr<Coveralls> &self, std::string message);
 
             std::shared_ptr<Coveralls> clone_me();
 

--- a/cpp-tests/scaffolding_tests/todolist/lib_todolist.cpp
+++ b/cpp-tests/scaffolding_tests/todolist/lib_todolist.cpp
@@ -95,8 +95,8 @@ void todolist::TodoList::clear_item(const std::string &todo) {
     this->items.erase(it);
 }
 
-void todolist::TodoList::make_default() {
-    todolist::set_default_list(this->shared_from_this());
+void todolist::TodoList::make_default(const std::shared_ptr<TodoList> &self) {
+    todolist::set_default_list(self);
 }
 
 #include <todolist_cpp_scaffolding.cpp>

--- a/cpp-tests/scaffolding_tests/todolist/lib_todolist.hpp
+++ b/cpp-tests/scaffolding_tests/todolist/lib_todolist.hpp
@@ -48,7 +48,7 @@ namespace {
             std::string text;
         };
 
-        class TodoList: public std::enable_shared_from_this<TodoList>{
+        class TodoList {
         public:
             TodoList() = default;
 
@@ -62,7 +62,7 @@ namespace {
             std::string get_last();
             std::string get_first();
             void clear_item(const std::string &item);
-            void make_default();
+            void make_default(const std::shared_ptr<TodoList> &self);
         private:
             std::vector<std::string> items;
             std::mutex items_mutex;


### PR DESCRIPTION
This also fixes a bug where some object functions wouldn't honor the `[Self=ByArc]` attribute