### PR TITLE
Remove workaround for chronological scaffolding test

### DIFF
--- a/cpp-tests/CMakeLists.txt
+++ b/cpp-tests/CMakeLists.txt
@@ -47,7 +47,6 @@ target_include_directories(uniffi_${TEST_NAME} PRIVATE scaffolding_tests/${TEST_
 add_executable(${TEST_NAME}-scaffolding-test tests/${TEST_NAME}/main.cpp ${BINDINGS_SRC_DIR}/${TEST_NAME}.cpp)
 target_include_directories(${TEST_NAME}-scaffolding-test PRIVATE ${BINDINGS_SRC_DIR} include)
 target_link_libraries(${TEST_NAME}-scaffolding-test uniffi_${TEST_NAME} Threads::Threads)
-target_compile_definitions(${TEST_NAME}-scaffolding-test PRIVATE SCAFFOLDING_TEST=1)
 
 add_test(NAME ${TEST_NAME}-scaffolding-test COMMAND ${TEST_NAME}-scaffolding-test)
 memcheck_test(${TEST_NAME}-scaffolding-test)

--- a/cpp-tests/scaffolding_tests/chronological/lib_chronological.cpp
+++ b/cpp-tests/scaffolding_tests/chronological/lib_chronological.cpp
@@ -14,9 +14,18 @@ chronological::duration chronological::return_duration(chronological::duration a
 
 std::string chronological::to_string_timestamp(chronological::timestamp a) {
     std::time_t time = std::chrono::system_clock::to_time_t(a);
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(a.time_since_epoch()).count() % 1000000000;
+    if (ns < 0) {
+        ns += 1000000000;
+        time -= 1;
+    }
+
     std::tm tm = *std::gmtime(&time);
     std::stringstream ss;
     ss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S");
+    ss<< "." << std::setfill('0') << std::setw(9) << ns;
+    ss << "Z";
+
     return ss.str();
 }
 

--- a/cpp-tests/tests/chronological/main.cpp
+++ b/cpp-tests/tests/chronological/main.cpp
@@ -53,32 +53,6 @@ void test_string_timestamps() {
     }
 }
 
-void test_scaffolding_string_timestamps() {
-    {
-        auto time_str = "1970-01-01T00:00:00";
-        auto time = time_from_string(time_str);
-
-        ASSERT_EQ(time_str, chronological::to_string_timestamp(time));
-    }
-
-    {
-        auto time_str = "1970-12-31T23:59:58";
-        auto time = time_from_string(time_str);
-
-        ASSERT_EQ(time_str, chronological::to_string_timestamp(time));
-    }
-
-    {
-        auto time = time_from_string("1979-11-05T00:06:01") + 283000200ns;
-        auto time2 = time_from_string("1979-11-05T00:06:00") + 283000100ns;
-
-        ASSERT_EQ(
-            time,
-            chronological::add(time2, time_span_seconds(1, 100))
-        );
-    }
-}
-
 int main() {
     ASSERT_EQ(
         epoch_second(101, 110),
@@ -110,11 +84,7 @@ int main() {
         chronological::return_duration(std::chrono::nanoseconds::max())
     );
 
-    #ifdef SCAFFOLDING_TEST
-    test_scaffolding_string_timestamps();
-    #else
     test_string_timestamps();
-    #endif
 
     auto before = std::chrono::system_clock::now();
     std::this_thread::sleep_for(1s);


### PR DESCRIPTION
Before it was not falling in line with the output received from the Rust library