### PR TITLE
Add define guard to internal ffi structs

### DIFF
--- a/bindgen/src/bindings/cpp/templates/scaffolding.hpp
+++ b/bindgen/src/bindings/cpp/templates/scaffolding.hpp
@@ -6,6 +6,8 @@
 extern "C" {
 #endif
 
+#ifndef UNIFFI_CPP_INTERNALSTRUCTS
+#define UNIFFI_CPP_INTERNALSTRUCTS
 struct ForeignBytes {
     int32_t len;
     uint8_t *data;
@@ -21,6 +23,8 @@ struct RustCallStatus {
     int8_t code;
     RustBuffer error_buf;
 };
+
+#endif
 
 typedef int ForeignCallback(uint64_t handle, uint32_t method, uint8_t *args_data, int32_t args_len, RustBuffer *buf_ptr);
 


### PR DESCRIPTION
Added define guard for internal ffi structs which caused redefinition errors when including multiple UniFFI c++ libraries in the same project