### PR TITLE
Fix RustStream constructor arguments ordering in templates/rust_buf_stream

### DIFF
--- a/bindgen/src/bindings/cpp/templates/rust_buf_stream.cpp
+++ b/bindgen/src/bindings/cpp/templates/rust_buf_stream.cpp
@@ -17,7 +17,7 @@ private:
 
 struct RustStream: std::basic_iostream<char> {
     RustStream(RustBuffer *buf):
-        streambuf(RustStreamBuffer(buf)), std::basic_iostream<char>(&streambuf) { }
+        std::basic_iostream<char>(&streambuf), streambuf(RustStreamBuffer(buf)) { }
 
     template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
     RustStream &operator>>(T &val) {


### PR DESCRIPTION
Hi, first of all - thanks for the great project!

My compiler is quite strict and complains about an error in on of the template files, this PR fixes it, basically ordering of constructor parameters is wrong:

```
error: field 'streambuf' will be initialized after base 'std::basic_iostream<char>' [-Werror,-Wreorder-ctor]
        streambuf(RustStreamBuffer(buf)), std::basic_iostream<char>(&streambuf) { }
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        std::basic_iostream<char>(&streambuf) streambuf(RustStreamBuffer(buf))
1 error generated.
```