### PR TITLE
Include vector header in generated header

### DIFF
--- a/bindgen/src/bindings/cpp/templates/wrapper.hpp
+++ b/bindgen/src/bindings/cpp/templates/wrapper.hpp
@@ -13,6 +13,7 @@
 #include <streambuf>
 #include <type_traits>
 #include <variant>
+#include <vector>
 
 {%- for include in self.includes() %}
 #include <{{ include }}>


### PR DESCRIPTION
It is not necessarily included by the other included headers, which could lead to a compilation error.