### PR TITLE
Revert naming chages to throw_underlying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### v0.7.2+v0.28.3
+
+----
+- Core: Remove `_uniffi_internal` prefix from the `throw_underlying` function
+
 #### v0.7.1+v0.28.3
 
 ----

--- a/bindgen/src/bindings/cpp/templates/err.hpp
+++ b/bindgen/src/bindings/cpp/templates/err.hpp
@@ -13,8 +13,7 @@ struct {{ class_name }}: std::runtime_error {
 
     virtual ~{{ class_name }}() = default;
 
-    // UniFFI internal function - do not call this manually!
-    virtual void _uniffi_internal_throw_underlying() {
+    virtual void throw_underlying() {
         throw *this;
     }
 
@@ -42,8 +41,7 @@ struct {{ variant.name()|class_name }}: {{ class_name }} {
     {{ variant.name()|class_name }}() : {{ class_name }}("") {}
     {{ variant.name()|class_name }}(const std::string &what_arg) : {{ class_name }}(what_arg) {}
 
-    // UniFFI internal function - do not call this manually!
-    void _uniffi_internal_throw_underlying() override {
+    void throw_underlying() override {
         throw *this;
     }
 

--- a/bindgen/src/bindings/cpp/templates/obj.cpp
+++ b/bindgen/src/bindings/cpp/templates/obj.cpp
@@ -23,7 +23,7 @@ namespace uniffi {
 }
 
 {% if ci.is_name_used_as_error(name) %}
-    void {{ impl_class_name }}::_uniffi_internal_throw_underlying() {
+    void {{ impl_class_name }}::throw_underlying() {
         throw *this;
     }
 {% endif %}

--- a/bindgen/src/bindings/cpp/templates/obj.hpp
+++ b/bindgen/src/bindings/cpp/templates/obj.hpp
@@ -84,8 +84,7 @@ struct {{ impl_class_name }}
     {%- endfor %}
 
     {% if ci.is_name_used_as_error(name) %}
-    // UniFFI internal function - do not call this manually!
-    void _uniffi_internal_throw_underlying();
+    void throw_underlying();
     {%- endif -%}
 private:
     {{ impl_class_name }}(const {{ impl_class_name }} &);

--- a/bindgen/src/bindings/cpp/templates/wrapper.cpp
+++ b/bindgen/src/bindings/cpp/templates/wrapper.cpp
@@ -45,7 +45,7 @@ void check_rust_call(const RustCallStatus &status, F error_cb) {
 
     case 1:
         if constexpr (!std::is_null_pointer_v<F>) {
-            error_cb(status.error_buf)->_uniffi_internal_throw_underlying();
+            error_cb(status.error_buf)->throw_underlying();
         }
         break;
 


### PR DESCRIPTION
Since it has uses, we're not detering users from calling this function