### PR TITLE
Expand the set of names for which `_` is appended to include few commonly used macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### v0.7.4+v0.28.3
+
+----
+- Core: Expand the set of names for which `_` is appended to include few commonly used macros
+
 #### v0.7.3+v0.28.3
 
 ----

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-cpp"
-version = "0.7.1+v.0.28.3"
+version = "0.7.3+v0.28.3"
 dependencies = [
  "anyhow",
  "askama",

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-cpp"
-version = "0.7.3+v0.28.3"
+version = "0.7.4+v0.28.3"
 edition = "2021"
 
 [dependencies]

--- a/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
+++ b/bindgen/src/bindings/cpp/gen_cpp/filters/mod.rs
@@ -17,7 +17,10 @@ use super::EnumStyle;
 
 type Result<T> = std::result::Result<T, askama::Error>;
 
-const RESERVED_CPP_KEYWORDS: [&str; 98] = [
+// Keywords and other commonly used words that are in fact macros that
+// expand to expressions (like `errno`).
+const RESERVED_CPP_WORDS: [&str; 100] = [
+    // Keywords
     "alignas",
     "alignof",
     "and",
@@ -116,6 +119,9 @@ const RESERVED_CPP_KEYWORDS: [&str; 98] = [
     "while",
     "xor",
     "xor_eq",
+    // Macros
+    "errno",
+    "assert",
 ];
 
 #[derive(Clone)]
@@ -143,7 +149,7 @@ impl CppCodeOracle {
 
     pub(crate) fn var_name(&self, nm: &str) -> String {
         let mut name = nm.to_string().to_snake_case();
-        if RESERVED_CPP_KEYWORDS.contains(&&*name) {
+        if RESERVED_CPP_WORDS.contains(&&*name) {
             name.push('_');
         }
         name

--- a/cpp-tests/tests/reserved_field_name/main.cpp
+++ b/cpp-tests/tests/reserved_field_name/main.cpp
@@ -3,8 +3,8 @@
 #include <reserved_field_name.hpp>
 
 int main() {
-    reserved_field_name::Foo foo = {42};
-    reserved_field_name::assert_this_is_42(foo);
+    reserved_field_name::Foo foo = {42, 42, 42};
+    reserved_field_name::assert_fields_are_42(foo);
 
     return 0;
 }

--- a/fixtures/reserved-field-name/src/lib.rs
+++ b/fixtures/reserved-field-name/src/lib.rs
@@ -1,9 +1,13 @@
 struct Foo {
     this: u32,
+    errno: u32,
+    assert: u32,
 }
 
-fn assert_this_is_42(foo: Foo) {
+fn assert_fields_are_42(foo: Foo) {
     assert_eq!(42, foo.this);
+    assert_eq!(42, foo.errno);
+    assert_eq!(42, foo.assert);
 }
 
 uniffi::include_scaffolding!("reserved_field_name");

--- a/fixtures/reserved-field-name/src/reserved_field_name.udl
+++ b/fixtures/reserved-field-name/src/reserved_field_name.udl
@@ -1,7 +1,9 @@
 dictionary Foo {
     u32 this;
+    u32 errno;
+    u32 assert;
 };
 
 namespace reserved_field_name {
-    void assert_this_is_42(Foo foo);
+    void assert_fields_are_42(Foo foo);
 };


### PR DESCRIPTION
Like `errno` or `assert`.